### PR TITLE
clear this.state before _loadState() in collection.js

### DIFF
--- a/src/syncers/collection.js
+++ b/src/syncers/collection.js
@@ -124,6 +124,8 @@ export default class CollectionSyncer extends BaseSyncer {
 				return items
 			}
 
+			this.state = this._initialState()
+			
 			items.forEach(item => {
 				this._set(item[this._id], item)
 			})


### PR DESCRIPTION
currently, after doing some `create` operations, when calling `_loadNewState()` to reload the collection, the newly created items cannot be removed, even if they don't match the query conditions of the collection. This PR fixes this by clearing `this.state` before doing `_loadState()` in collection.js
