### PR TITLE
pagination support

### DIFF
--- a/src/syncers/collection.js
+++ b/src/syncers/collection.js
@@ -137,6 +137,11 @@ export default class CollectionSyncer extends BaseSyncer {
 
 			this.state = this._initialState()
 
+			// if the service is paginated
+			if (Array.isArray(items) === false && typeof items.data !== 'undefined') {
+				items = items.data
+			}
+
 			items.forEach(item => {
 				this._set(item[this._id], item)
 			})


### PR DESCRIPTION
simply added pagination support in `collection.js`: if paginated, use `items.data` instead of `items`.
